### PR TITLE
PRO-5776: a4 demo of SASS compilation within palette (do not merge)

### DIFF
--- a/modules/@apostrophecms-pro/palette/scss/palette.scss
+++ b/modules/@apostrophecms-pro/palette/scss/palette.scss
@@ -1,0 +1,7 @@
+body {
+  background-color: $background-color;
+}
+
+* {
+  color: purple !important;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,13 @@
       "dependencies": {
         "@apostrophecms-pro/basics": "^1.3.1",
         "@apostrophecms-pro/document-versions": "^2.0.0",
-        "@apostrophecms-pro/palette": "apostrophecms/palette#pro-5776",
+        "@apostrophecms-pro/palette": "4.1.0-alpha.1",
         "apostrophe": "^4.0.0",
+        "lodash": "^4.17.21",
         "node-fetch": "^2.6.5",
         "qs": "^6.9.6",
-        "require-all": "^3.0.0"
+        "require-all": "^3.0.0",
+        "sass": "^1.74.1"
       },
       "devDependencies": {
         "eslint": "^8.0.0",
@@ -26,6 +28,22 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "../palette": {
+      "name": "@apostrophecms-pro/palette",
+      "version": "4.1.0-alpha.1",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@apostrophecms-pro/licensing": "^1.0.0",
+        "cuid": "^2.1.8",
+        "klona": "^2.0.4",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "eslint": "^7.18.0",
+        "eslint-config-apostrophe": "^3.4.1",
+        "eslint-plugin-vue": "^7.4.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -67,14 +85,8 @@
       }
     },
     "node_modules/@apostrophecms-pro/palette": {
-      "version": "4.0.1",
-      "resolved": "git+ssh://git@github.com/apostrophecms/palette.git#7ca6551b274b510d23b79a2ac966890841c007ff",
-      "dependencies": {
-        "@apostrophecms-pro/licensing": "^1.0.0",
-        "cuid": "^2.1.8",
-        "klona": "^2.0.4",
-        "lodash": "^4.17.21"
-      }
+      "resolved": "../palette",
+      "link": true
     },
     "node_modules/@apostrophecms/vue-material-design-icons": {
       "version": "1.0.0",
@@ -8404,9 +8416,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.1.tgz",
-      "integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.74.1.tgz",
+      "integrity": "sha512-w0Z9p/rWZWelb88ISOLyvqTWGmtmu2QJICqDBGyNnfG4OUnPX9BBjjYIXUpXCMOOg5MQWNpqzt876la1fsTvUA==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,17 +23,19 @@
   "dependencies": {
     "@apostrophecms-pro/basics": "^1.3.1",
     "@apostrophecms-pro/document-versions": "^2.0.0",
-    "@apostrophecms-pro/palette": "apostrophecms/palette#pro-5776",
+    "@apostrophecms-pro/palette": "4.1.0-alpha.1",
     "apostrophe": "^4.0.0",
+    "lodash": "^4.17.21",
     "node-fetch": "^2.6.5",
     "qs": "^6.9.6",
-    "require-all": "^3.0.0"
+    "require-all": "^3.0.0",
+    "sass": "^1.74.1"
   },
   "devDependencies": {
     "eslint": "^8.0.0",
     "eslint-config-apostrophe": "^4.0.0",
+    "nodemon": "^3.0.1",
     "stylelint": "^15.0.0",
-    "stylelint-config-apostrophe": "^3.0.0",
-    "nodemon": "^3.0.1"
+    "stylelint-config-apostrophe": "^3.0.0"
   }
 }


### PR DESCRIPTION
Demonstrate the custom server side rendering technique. Converts palette settings directly to SASS variables before importing `palette.scss`, which currently just takes the background color setting and applies it, and also intentionally also contains a rule to make an obvious change to the text color to verify it is in the mix.