### PR TITLE
Fix palette tab display

### DIFF
--- a/modules/@apostrophecms/global/ui/apos/components/AssemblyInputFontFamily.vue
+++ b/modules/@apostrophecms/global/ui/apos/components/AssemblyInputFontFamily.vue
@@ -15,7 +15,7 @@
           <option
             v-for="choice in choices" :key="choice.value"
             :value="choice.value"
-            :selected="choice.value === value.data"
+            :selected="choice.value === modelValue.data"
           >
             {{ choice.label }}
           </option>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
Opening the palette menu and selecting a tab using the `AssemblyInputFontFamily` field to add a google fonts script field will crash palette updates until a page refresh. The engineering team identified the fact that the Vue component powering this field had legacy Vue 2 code that is incompatible with Vue 3. Updating this component fixed the problem. It was also verified that adding a Google script into the global configuration properly configured the palette menu that uses this field.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1) Create a new project using this template.
2) Add at least one site.
3) Open the Palette menu and navigate to the 'Typography' tab from the dropdown.
4) Confirm that there are three sub-groups.
## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
